### PR TITLE
Fix CI failure: mock comfyUIAxios in onMessage test to prevent config…

### DIFF
--- a/src/__tests__/onMessage.test.ts
+++ b/src/__tests__/onMessage.test.ts
@@ -6,6 +6,12 @@ import logger from '../server/utils/logger';
 import { QueueItem } from '@shared/types/History';
 
 // Mock dependencies
+jest.mock('../server/utils/comfyAPIUtils/comfyUIAxios', () => ({
+    comfyUIAxios: { get: jest.fn(), post: jest.fn() },
+    clientId: 'test-client-id',
+    comfyUIUrl: 'http://localhost:8188',
+    httpsAgent: {},
+}));
 jest.mock('../server/utils/comfyAPIUtils/getQueue');
 jest.mock('../server/utils/comfyAPIUtils/generateImage/getOutputImages');
 jest.mock('../server/utils/logger');


### PR DESCRIPTION
The onMessage.test.ts suite was failing because Jest's automocking of getQueue still evaluated comfyUIAxios/index.ts to determine its shape, which called config.get('comfyui_url') at module load time — a key that doesn't exist in the test environment. Adding a manual factory mock for comfyUIAxios prevents the real module from being evaluated.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: only adjusts Jest mocking in a test file to prevent module-load config access during CI; no production logic changes.
> 
> **Overview**
> Fixes CI failures in `onMessage.test.ts` by adding a manual Jest factory mock for `comfyUIAxios` (and its exported `clientId`, `comfyUIUrl`, `httpsAgent`) so the real module isn’t evaluated and no missing `config.get('comfyui_url')` is triggered during test setup.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 4c4608ca0dea9f5cd95f128d41739902faca207e. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->